### PR TITLE
257: Remove ingress rules that set x-forgerock-transaction-id

### DIFF
--- a/kustomize/base/ingress/ingress.yaml
+++ b/kustomize/base/ingress/ingress.yaml
@@ -19,9 +19,6 @@ metadata:
     # RCS Agent websockets
     nginx.org/websocket-services: "rcs-agent"
     nginx.ingress.kubernetes.io/websocket-services: "rcs-agent"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      add_header X-ForgeRock-TransactionId $req_id;
-      proxy_set_header X-ForgeRock-TransactionId $req_id;
   name: forgerock
 spec:
   ingressClassName: nginx


### PR DESCRIPTION
Despite IG being correctly configured to set the
x-forgerock-transaction-id to the value of the x-fapi-interaction-id this value was not being used by AM. This is because the ingress rules used by AM in the forgeops CDK deployment had an ingress rule that set the x-forgerock-transacion-id to the X-Request-ID being set by nginx.

This commit removes those rules so that the forgeops platform will use the provided x-forgerock-transaction-id

Have tried neater ways to do this using kustomise overlays, but it seems that is very hard to do right now due to the way forgeops works... Lee from forgeops is looking at how we can do that without needing a branch in forgeops, but for now, this is our solution. 

Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/257