### PR TITLE
669: Setting secret-agent version to install as v1.1.5

### DIFF
--- a/bin/utils.py
+++ b/bin/utils.py
@@ -48,7 +48,7 @@ REQ_VERSIONS ={
     'secret-agent': {
         'MIN': 'v1.1.5',
         'MAX': 'v100.0.0',
-        'DEFAULT': 'latest',
+        'DEFAULT': 'v1.1.5',
     },
     'cert-manager': {
         'MIN': 'v1.5.1',


### PR DESCRIPTION
Installing secret-agent v1.1.5 from tag, rather than relying on latest.

https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/669