### PR TITLE
1214: Increase AM maxHttpHeaderSize to 16k

### DIFF
--- a/kustomize/base/am-cdk/deployment.yaml
+++ b/kustomize/base/am-cdk/deployment.yaml
@@ -67,8 +67,13 @@ spec:
         image: am
         imagePullPolicy: Always
         command:
-          - bash
-          - /home/forgerock/docker-entrypoint.sh
+          - /bin/bash
+          - -c
+          - |
+            echo "Setting Tomcat maxHttpHeaderSize to 16k"
+            # maxHttpHeaderSize is not specified in server.xml (defaults to 8k), append the config to the Connector sections of server.xml
+            sed -i 's/redirectPort="8443" \/>/redirectPort="8443" maxHttpHeaderSize="16384" \/>/g' /usr/local/tomcat/conf/server.xml
+            /home/forgerock/docker-entrypoint.sh
         env:
         - name: NAMESPACE
           valueFrom:


### PR DESCRIPTION
AM currently does not configure the Tomcat maxHttpHeaderSize, the default of 8k is used.

Issues have been observed with OAuth2.0 /authorize calls passing headers larger than 8k.

Applying the maxHttpHeaderSize configuration to the Tomcat server.xml. Using sed to append the configuration to the end of the Connector elements in the configuration file.

Note: FIDC sets maxHttpHeaderSize as 16k, this change bring CDK deployments in line with this.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1214