### PR TITLE
1194: Update development environments to use forgeops version matching Identity Cloud

### DIFF
--- a/kustomize/base/am/deployment.yaml
+++ b/kustomize/base/am/deployment.yaml
@@ -14,6 +14,7 @@ spec:
       annotations:
         "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
     spec:
+      serviceAccountName: am-kubernetes
       securityContext:
         runAsUser: 11111
         runAsGroup: 0
@@ -32,6 +33,9 @@ spec:
         - /bin/bash
         - -c
         - |
+          echo "Setting Tomcat maxHttpHeaderSize to 16k"
+          # maxHttpHeaderSize is not specified in server.xml (defaults to 8k), append the config to the Connector sections of server.xml
+          sed -i 's/redirectPort="8443" \/>/redirectPort="8443" maxHttpHeaderSize="16384" \/>/g' /usr/local/tomcat/conf/server.xml
           if [ -d /fbc/config ];
           then
             echo "Existing openam configuration found. Skipping copy"
@@ -114,9 +118,9 @@ spec:
           timeoutSeconds: 5
         resources:
           limits:
-            memory: 1800Mi
+            memory: 3500Mi
           requests:
-            memory: 1800Mi
+            memory: 3500Mi
             cpu: 250m
         volumeMounts:
         - name: new-truststore

--- a/kustomize/base/ds-idrepo/ds-idrepo.yaml
+++ b/kustomize/base/ds-idrepo/ds-idrepo.yaml
@@ -54,11 +54,11 @@ spec:
 
     # The volume spec for the DS data. This is the same as the Kubernetes PVC volume spec.
     volumeClaimSpec:
-      storageClassName: fast
+      storageClassName: standard-rwo
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:
-          storage: 10Gi
+          storage: 1Gi
       # Optional: If the volume dataSource is provided *AND* the PVC does not yet exist, the directory PVCs will be
       # initialized from the contents of the snapshot. They will NOT be initialized from the setup script.
       #


### PR DESCRIPTION
Upgrade forgeops from 7.3 -> 7.4

Changes are based off previous changes made to 7.3

https://github.com/ForgeRock/forgeops/compare/release/7.3-20230706...SecureApiGateway:forgeops:release/sapig/7.3-20230706?expand=1

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1194