### PR TITLE
1345: Investigate configuring AM truststore to enable AM to connect to OB directory jwks_uri

### DIFF
--- a/kustomize/base/secrets/secret_agent_config.yaml
+++ b/kustomize/base/secrets/secret_agent_config.yaml
@@ -104,12 +104,7 @@ spec:
           # multiple keys
           #   truststoreImportPaths: ["platform-ca/ca", "vault-secrets/vault-ca"]
           pemFormat: true
-          truststoreImportPaths: ["platform-ca/ca"]
-      - name: obcacerts
-        type: truststore
-        spec:
-          pemFormat: true
-          truststoreImportPaths: ["ob-ca/issuing","ob-ca/root"]
+          truststoreImportPaths: ["platform-ca/ca", "ob-ca/issuing", "ob-ca/root"]
   - name: truststore
     keys:
       - name: cacerts

--- a/kustomize/base/secrets/secret_agent_config.yaml
+++ b/kustomize/base/secrets/secret_agent_config.yaml
@@ -76,7 +76,6 @@ spec:
     keys:
 
       # The keystore alias
-
       - name: cacerts
         # A truststore that is compatible as a java trust store that as a
         # copy of the system root store at the time of creation and contains
@@ -106,7 +105,11 @@ spec:
           #   truststoreImportPaths: ["platform-ca/ca", "vault-secrets/vault-ca"]
           pemFormat: true
           truststoreImportPaths: ["platform-ca/ca"]
-
+      - name: obcacerts
+        type: truststore
+        spec:
+          pemFormat: true
+          truststoreImportPaths: ["ob-ca/issuing","ob-ca/root"]
   - name: truststore
     keys:
       - name: cacerts


### PR DESCRIPTION
Add issuing-ca and root-ca into existing cacerts secret

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1345